### PR TITLE
removed `/app` volume from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN sh $BITNAMI_PREFIX/install.sh
 COPY rootfs/ /
 
 EXPOSE 80 443
-VOLUME ["$BITNAMI_APP_VOL_PREFIX/conf", "$BITNAMI_APP_VOL_PREFIX/logs", "/app"]
+VOLUME ["$BITNAMI_APP_VOL_PREFIX/conf", "$BITNAMI_APP_VOL_PREFIX/logs"]
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -335,6 +335,12 @@ using the `bats` command.
 bats test.sh
 ```
 
+# Changelog
+
+## development (2015-10-05)
+
+- `/app` directory is no longer exported as a volume. This caused problems when building on top of the image, since changes in the volume are not persisted between Dockerfile `RUN` instructions. To keep the previous behavior (so that you can mount the volume in another container), create the container with the `-v /app` option.
+
 # Contributing
 
 We'd love for you to contribute to this container. You can request new features by creating an

--- a/post-install.sh
+++ b/post-install.sh
@@ -5,6 +5,9 @@ cd $BITNAMI_APP_DIR
 mv conf conf.defaults
 mv html html.defaults
 
+# Create an empty html directory
+mkdir -p html
+
 # Setup mount point symlinks
 ln -s $BITNAMI_APP_DIR/conf $BITNAMI_APP_VOL_PREFIX/conf
 ln -s $BITNAMI_APP_DIR/logs $BITNAMI_APP_VOL_PREFIX/logs

--- a/test.sh
+++ b/test.sh
@@ -74,7 +74,6 @@ add_vhost() {
     run grep "\"Volumes\":" -A 3
     [[ "$output" =~ "$VOL_PREFIX/logs" ]]
     [[ "$output" =~ "$VOL_PREFIX/conf" ]]
-    [[ "$output" =~ "/app" ]]
   }
 }
 


### PR DESCRIPTION
Specifying a volume at `/app` (in the Dockerfile) makes it difficult to
use this image as a base image for derived images. Due to this, we have
removed the `VOLUME` instruction that mounts `/app` as a volume.

The `/app` path continues to function like it did before. As a result if
you want to mount your html source into the container, mount it at
`/app`
using `-v /path/on/application/source:/app`.

One advantage of mounting/installing your application at `/app` is that
the image will automatically update the ownership of the
files/directories in `/app` so that it is accessible by the `nginx`
daemon.