### PR TITLE
Made chown only change the GROUP owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=nginx \
     BITNAMI_APP_USER=daemon \
-    BITNAMI_APP_GROUP=daemon \
     BITNAMI_APP_DAEMON=nginx \
     BITNAMI_APP_VERSION=1.9.15-1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Bitnami <containers@bitnami.com>
 
 ENV BITNAMI_APP_NAME=nginx \
     BITNAMI_APP_USER=daemon \
+    BITNAMI_APP_GROUP=daemon \
     BITNAMI_APP_DAEMON=nginx \
     BITNAMI_APP_VERSION=1.9.15-1
 

--- a/rootfs/etc/cont-init.d/01-bitnami-nginx
+++ b/rootfs/etc/cont-init.d/01-bitnami-nginx
@@ -8,4 +8,4 @@ if [ ! "$(ls -A /app)" ]; then
   cp -r $BITNAMI_APP_DIR/html.defaults/* $BITNAMI_APP_DIR/html
 fi
 
-chown -R $BITNAMI_APP_USER:$BITNAMI_APP_GROUP $BITNAMI_APP_VOL_PREFIX/logs/ $BITNAMI_APP_VOL_PREFIX/conf/ /app/ || true
+chown -R :$BITNAMI_APP_GROUP $BITNAMI_APP_VOL_PREFIX/logs/ $BITNAMI_APP_VOL_PREFIX/conf/ /app/ || true

--- a/rootfs/etc/cont-init.d/01-bitnami-nginx
+++ b/rootfs/etc/cont-init.d/01-bitnami-nginx
@@ -8,4 +8,4 @@ if [ ! "$(ls -A /app)" ]; then
   cp -r $BITNAMI_APP_DIR/html.defaults/* $BITNAMI_APP_DIR/html
 fi
 
-chown -R :$BITNAMI_APP_GROUP $BITNAMI_APP_VOL_PREFIX/logs/ $BITNAMI_APP_VOL_PREFIX/conf/ /app/ || true
+chown -R :$BITNAMI_APP_USER $BITNAMI_APP_VOL_PREFIX/logs/ $BITNAMI_APP_VOL_PREFIX/conf/ /app/ || true

--- a/rootfs/etc/cont-init.d/01-bitnami-nginx
+++ b/rootfs/etc/cont-init.d/01-bitnami-nginx
@@ -8,4 +8,4 @@ if [ ! "$(ls -A /app)" ]; then
   cp -r $BITNAMI_APP_DIR/html.defaults/* $BITNAMI_APP_DIR/html
 fi
 
-chown -R $BITNAMI_APP_USER:$BITNAMI_APP_USER $BITNAMI_APP_VOL_PREFIX/logs/ $BITNAMI_APP_VOL_PREFIX/conf/ /app/ || true
+chown -R $BITNAMI_APP_USER:$BITNAMI_APP_GROUP $BITNAMI_APP_VOL_PREFIX/logs/ $BITNAMI_APP_VOL_PREFIX/conf/ /app/ || true


### PR DESCRIPTION
This allows to better customize the security for the files changed by bitnami server, so that the bitnami user can be configured as a local host user, and have access to the files.