### PR TITLE
Update nginx port in README, docker-compose.yml and kubernetes.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ services:
   nginx:
     image: 'bitnami/nginx:latest'
     ports:
-      - '80:80'
-      - '443:443'
+      - '80:8080'
+      - '443:8443'
     volumes:
       - /path/to/app:/app
 ```
 
 # Accessing your server from the host
 
-To access your web server from your host machine you can ask Docker to map a random port on your host to ports `80` and `443` exposed in the container.
+To access your web server from your host machine you can ask Docker to map a random port on your host to ports `8080` and `8443` exposed in the container.
 
 ```bash
 $ docker run --name nginx -P bitnami/nginx:latest
@@ -96,17 +96,17 @@ Run `docker port` to determine the random ports Docker assigned.
 
 ```bash
 $ docker port nginx
-443/tcp -> 0.0.0.0:32768
-80/tcp -> 0.0.0.0:32769
+8443/tcp -> 0.0.0.0:32768
+8080/tcp -> 0.0.0.0:32769
 ```
 
 You can also manually specify the ports you want forwarded from your host to the container.
 
 ```bash
-$ docker run -p 8080:80 -p 8443:443 bitnami/nginx:latest
+$ docker run -p 9000:8080 -p 9443:8443 bitnami/nginx:latest
 ```
 
-Access your web server in the browser by navigating to [http://localhost:8080](http://localhost:8080/).
+Access your web server in the browser by navigating to [http://localhost:9000](http://localhost:9000/).
 
 # Configuration
 
@@ -120,7 +120,7 @@ For example, in order add a vhost for `www.example.com`:
 
 ```nginx
 server {
-  listen 0.0.0.0:80;
+  listen 0.0.0.0:8080;
   server_name www.example.com;
   root /app
   index index.htm index.html
@@ -144,8 +144,8 @@ services:
   mariadb:
     image: 'bitnami/nginx:latest'
     ports:
-      - '80:80'
-      - '443:443'
+      - '80:8080'
+      - '443:8443'
     volumes:
       - /path/to/my_vhost.conf:/bitnami/nginx/conf/vhosts/my_vhost.conf:ro
 ```
@@ -185,8 +185,8 @@ services:
   nginx:
     image: 'bitnami/nginx:latest'
     ports:
-    - '80:80'
-    - '443:443'
+    - '80:8080'
+    - '443:8443'
     volumes:
     - /path/to/nginx-persistence/nginx/conf/bitnami/certs:/bitnami/nginx/conf/bitnami/certs
 ```
@@ -214,8 +214,8 @@ services:
   nginx:
     image: 'bitnami/nginx:latest'
     ports:
-      - '80:80'
-      - '443:443'
+      - '80:8080'
+      - '443:8443'
     volumes:
       - /path/to/nginx-persistence:/bitnami
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     labels:
       kompose.service.type: nodeport
     ports:
-      - '80:80'
-      - '443:443'
+      - '80:8080'
+      - '443:8443'
     volumes:
       - 'nginx_data:/bitnami'
 

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -13,10 +13,10 @@ items:
     ports:
     - name: "80"
       port: 80
-      targetPort: 80
+      targetPort: 8080
     - name: "443"
       port: 443
-      targetPort: 443
+      targetPort: 8443
     selector:
       io.kompose.service: nginx
     type: NodePort
@@ -28,6 +28,8 @@ items:
     annotations:
       kompose.service.type: nodeport
     creationTimestamp: null
+    labels:
+      io.kompose.service: nginx
     name: nginx
   spec:
     replicas: 1
@@ -39,15 +41,25 @@ items:
         labels:
           io.kompose.service: nginx
       spec:
+        initContainers:
+        - name: volume-permissions
+          image: busybox
+          command: ['sh', '-c', 'chmod -R g+rwX /bitnami']
+          volumeMounts:
+          - mountPath: /bitnami
+            name: nginx-nginx-data
         containers:
         - image: bitnami/nginx:latest
           name: nginx
+          env:
+          - name: NAMI_LOG_LEVEL
+            value: trace8
           ports:
-          - containerPort: 80
-          - containerPort: 443
+          - containerPort: 8080
+          - containerPort: 8443
           resources: {}
           volumeMounts:
-          - mountPath: /bitnami/nginx
+          - mountPath: /bitnami
             name: nginx-nginx-data
         restartPolicy: Always
         volumes:
@@ -71,4 +83,3 @@ items:
   status: {}
 kind: List
 metadata: {}
-

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -51,9 +51,6 @@ items:
         containers:
         - image: bitnami/nginx:latest
           name: nginx
-          env:
-          - name: NAMI_LOG_LEVEL
-            value: trace8
           ports:
           - containerPort: 8080
           - containerPort: 8443


### PR DESCRIPTION
 **Description of the change**

- Since we move the nginx container to run as non-root, the ports taken by nginx are 8080/8443 instead of 80/443. 
- Added init-container to change permissions of the persistent volume in kubernertes.yml. We have to set proper permissions so the nginx module can be initialized.

**Benefits**

- Files and documentation are up-to-date.
- kubernetes.yml works 

**Possible drawbacks**

- Use an init-container to change the permissions of a persistent volume for a non-root container does not seem the proper solution to me.

**Applicable issues**

This one https://github.com/bitnami/bitnami-docker-nginx/issues/85

