### PR TITLE
NGINX - Avoid using sed 'inplace' replacements and check for write permissions

### DIFF
--- a/1.16/debian-9/rootfs/libnginx.sh
+++ b/1.16/debian-9/rootfs/libnginx.sh
@@ -132,7 +132,7 @@ nginx_config_http_port() {
         debug "Configuring default HTTP port..."
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
         nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
-        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
+        echo "$nginx_configuration" > "${NGINX_CONFDIR}/nginx.conf"
     fi
 }
 

--- a/1.16/debian-9/rootfs/libnginx.sh
+++ b/1.16/debian-9/rootfs/libnginx.sh
@@ -204,7 +204,7 @@ nginx_initialize() {
         # The "user" directive makes sense only if the master process runs with super-user privileges
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
         nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
-        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
+        echo "$nginx_configuration" > "${NGINX_CONFDIR}/nginx.conf"
     fi
 
     debug "Updating 'nginx.conf' based on user configuration..."

--- a/1.16/debian-9/rootfs/libnginx.sh
+++ b/1.16/debian-9/rootfs/libnginx.sh
@@ -99,6 +99,24 @@ EOF
 }
 
 ########################
+# Check if NGINX configurtaion file is writable by current user
+# Globals:
+#   NGINX_CONFDIR
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+#########################
+is_nginx_config_writable() {
+    if >> "${NGINX_CONFDIR}/nginx.conf"; then
+	true
+    else
+        warn "'nginx.conf' is not writable by current user. Skipping modifications..."
+        false
+    fi
+}
+
+########################
 # Configure default HTTP port
 # Globals:
 #   NGINX_CONFDIR
@@ -109,9 +127,12 @@ EOF
 #########################
 nginx_config_http_port() {
     local http_port=${1:-8080}
-    debug "Configuring default HTTP port..."
-    # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-    sed -i -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf"
+    if is_nginx_config_writable; then
+        debug "Configuring default HTTP port..."
+        # TODO: find an appropriate NGINX parser to avoid 'sed calls'
+        local nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
+        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
+    fi
 }
 
 ########################
@@ -177,14 +198,15 @@ nginx_initialize() {
         if [[ -n "${NGINX_DAEMON_USER:-}" ]]; then
             chown -R "${NGINX_DAEMON_USER:-}" "${NGINX_CONFDIR}" "$NGINX_TMPDIR"
         fi
-    else
+    elif is_nginx_config_writable; then
         # The "user" directive makes sense only if the master process runs with super-user privileges
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-        sed -i -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf"
+        local nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
+        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
     fi
 
     debug "Updating 'nginx.conf' based on user configuration..."
     if [[ -n "${NGINX_HTTP_PORT_NUMBER:-}" ]]; then
-      nginx_config_http_port "${NGINX_HTTP_PORT_NUMBER}"
+        nginx_config_http_port "${NGINX_HTTP_PORT_NUMBER}"
     fi
 }

--- a/1.16/debian-9/rootfs/libnginx.sh
+++ b/1.16/debian-9/rootfs/libnginx.sh
@@ -99,7 +99,7 @@ EOF
 }
 
 ########################
-# Check if NGINX configurtaion file is writable by current user
+# Check if NGINX configuration file is writable by current user
 # Globals:
 #   NGINX_CONFDIR
 # Arguments:
@@ -128,9 +128,10 @@ is_nginx_config_writable() {
 nginx_config_http_port() {
     local http_port=${1:-8080}
     if is_nginx_config_writable; then
+        local nginx_configuration
         debug "Configuring default HTTP port..."
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-        local nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
+        nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
         echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
     fi
 }
@@ -199,9 +200,10 @@ nginx_initialize() {
             chown -R "${NGINX_DAEMON_USER:-}" "${NGINX_CONFDIR}" "$NGINX_TMPDIR"
         fi
     elif is_nginx_config_writable; then
+        local nginx_configuration
         # The "user" directive makes sense only if the master process runs with super-user privileges
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-        local nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
+        nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
         echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
     fi
 

--- a/1.16/ol-7/rootfs/libnginx.sh
+++ b/1.16/ol-7/rootfs/libnginx.sh
@@ -132,7 +132,7 @@ nginx_config_http_port() {
         debug "Configuring default HTTP port..."
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
         nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
-        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
+        echo "$nginx_configuration" > "${NGINX_CONFDIR}/nginx.conf"
     fi
 }
 

--- a/1.16/ol-7/rootfs/libnginx.sh
+++ b/1.16/ol-7/rootfs/libnginx.sh
@@ -204,7 +204,7 @@ nginx_initialize() {
         # The "user" directive makes sense only if the master process runs with super-user privileges
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
         nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
-        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
+        echo "$nginx_configuration" > "${NGINX_CONFDIR}/nginx.conf"
     fi
 
     debug "Updating 'nginx.conf' based on user configuration..."

--- a/1.16/ol-7/rootfs/libnginx.sh
+++ b/1.16/ol-7/rootfs/libnginx.sh
@@ -99,6 +99,24 @@ EOF
 }
 
 ########################
+# Check if NGINX configurtaion file is writable by current user
+# Globals:
+#   NGINX_CONFDIR
+# Arguments:
+#   None
+# Returns:
+#   Boolean
+#########################
+is_nginx_config_writable() {
+    if >> "${NGINX_CONFDIR}/nginx.conf"; then
+	true
+    else
+        warn "'nginx.conf' is not writable by current user. Skipping modifications..."
+        false
+    fi
+}
+
+########################
 # Configure default HTTP port
 # Globals:
 #   NGINX_CONFDIR
@@ -109,9 +127,12 @@ EOF
 #########################
 nginx_config_http_port() {
     local http_port=${1:-8080}
-    debug "Configuring default HTTP port..."
-    # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-    sed -i -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf"
+    if is_nginx_config_writable; then
+        debug "Configuring default HTTP port..."
+        # TODO: find an appropriate NGINX parser to avoid 'sed calls'
+        local nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
+        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
+    fi
 }
 
 ########################
@@ -177,14 +198,15 @@ nginx_initialize() {
         if [[ -n "${NGINX_DAEMON_USER:-}" ]]; then
             chown -R "${NGINX_DAEMON_USER:-}" "${NGINX_CONFDIR}" "$NGINX_TMPDIR"
         fi
-    else
+    elif is_nginx_config_writable; then
         # The "user" directive makes sense only if the master process runs with super-user privileges
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-        sed -i -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf"
+        local nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
+        echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
     fi
 
     debug "Updating 'nginx.conf' based on user configuration..."
     if [[ -n "${NGINX_HTTP_PORT_NUMBER:-}" ]]; then
-      nginx_config_http_port "${NGINX_HTTP_PORT_NUMBER}"
+        nginx_config_http_port "${NGINX_HTTP_PORT_NUMBER}"
     fi
 }

--- a/1.16/ol-7/rootfs/libnginx.sh
+++ b/1.16/ol-7/rootfs/libnginx.sh
@@ -99,7 +99,7 @@ EOF
 }
 
 ########################
-# Check if NGINX configurtaion file is writable by current user
+# Check if NGINX configuration file is writable by current user
 # Globals:
 #   NGINX_CONFDIR
 # Arguments:
@@ -128,9 +128,10 @@ is_nginx_config_writable() {
 nginx_config_http_port() {
     local http_port=${1:-8080}
     if is_nginx_config_writable; then
+        local nginx_configuration
         debug "Configuring default HTTP port..."
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-        local nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
+        nginx_configuration="$(sed -E "s/(listen\s+)[0-9]{1,5};/\1${http_port};/g" "${NGINX_CONFDIR}/nginx.conf")"
         echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
     fi
 }
@@ -199,9 +200,10 @@ nginx_initialize() {
             chown -R "${NGINX_DAEMON_USER:-}" "${NGINX_CONFDIR}" "$NGINX_TMPDIR"
         fi
     elif is_nginx_config_writable; then
+        local nginx_configuration
         # The "user" directive makes sense only if the master process runs with super-user privileges
         # TODO: find an appropriate NGINX parser to avoid 'sed calls'
-        local nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
+        nginx_configuration="$(sed -E "s/(^user)/# \1/g" "${NGINX_CONFDIR}/nginx.conf")"
         echo "$nginx_configuration" | tee "${NGINX_CONFDIR}/nginx.conf" > /dev/null
     fi
 


### PR DESCRIPTION
**Description of the change**

This PR ensure that NGINX doesn't write on any file without write permissions an avoid using sed 'in-place' substitutions.

