### PR TITLE
Exposing env NGINX_HTTP_PORT_NUMBER instead of 8080 and 8443.

### DIFF
--- a/1.16/debian-9/Dockerfile
+++ b/1.16/debian-9/Dockerfile
@@ -20,10 +20,10 @@ RUN /postunpack.sh
 ENV BITNAMI_APP_NAME="nginx" \
     BITNAMI_IMAGE_VERSION="1.16.1-debian-9-r41" \
     NAMI_PREFIX="/.nami" \
-    PATH="/opt/bitnami/nginx/sbin:$PATH"
+    PATH="/opt/bitnami/nginx/sbin:$PATH" \
+    NGINX_HTTP_PORT_NUMBER=8080
 
-EXPOSE 8080 8443
-
+EXPOSE ${NGINX_HTTP_PORT_NUMBER}
 WORKDIR /app
 USER 1001
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
The ports in Dockerfile are hardcoded.
`EXPOSE 8080 8443
`
I have set the port to 8000 using env.
`ENV NGINX_HTTP_PORT_NUMBER=8000
`
No matter which ports we used these two are also there:
```
"ExposedPorts": {
                "8000/tcp": {},
                "8080/tcp": {},
                "8443/tcp": {}
            },
```
I think that the solution for exposing more ports than we want is to expose not hardcoded number, but env, which user can later change in Dockerfile. 
```
ENV BITNAMI_APP_NAME="nginx" \
    BITNAMI_IMAGE_VERSION="1.16.1-debian-9-r41" \
    NAMI_PREFIX="/.nami" \
    PATH="/opt/bitnami/nginx/sbin:$PATH" \
    NGINX_HTTP_PORT_NUMBER=8080

EXPOSE ${NGINX_HTTP_PORT_NUMBER}
```
What do you think about it?

