### PR TITLE
Documentation: bump revision for dynamic modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Below is an example Dockerfile to build and install the NGINX Perl module (`ngx_
 
 ```Dockerfile
 ARG NGINX_VERSION=1.19.6
-ARG BITNAMI_NGINX_REVISION=r0
+ARG BITNAMI_NGINX_REVISION=r1
 ARG BITNAMI_NGINX_TAG=${NGINX_VERSION}-debian-10-${BITNAMI_NGINX_REVISION}
 
 FROM bitnami/nginx:${BITNAMI_NGINX_TAG} AS builder


### PR DESCRIPTION
The documentation to add custom dynamic modules used 1.19.6-debian-10-r0 as an example.  Unfortunately the first nginx
version that uses dynamic modules is 1.19.6-debian-10-r1.
